### PR TITLE
Update for JupyterLab 0.32.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,11 @@
     "watch": "tsc -w"
   },
   "dependencies": {
-    "@jupyterlab/application": "^0.15.0",
-    "@jupyterlab/filebrowser": "^0.15.0",
-    "@jupyterlab/mainmenu": "^0.4.0",
-    "@jupyterlab/launcher": "^0.15.0",
-    "@jupyterlab/apputils": "^0.15.0"
+    "@jupyterlab/application": "^0.16.0",
+    "@jupyterlab/filebrowser": "^0.16.0",
+    "@jupyterlab/mainmenu": "^0.5.0",
+    "@jupyterlab/launcher": "^0.16.0",
+    "@jupyterlab/apputils": "^0.16.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",


### PR DESCRIPTION
CC @wolfv.

Test using 

```bash
pip install --pre jupyterlab # to get the 0.32 RC.
jupyter labextension install ./path/to/this/repo
```
