### PR TITLE
Only copy grapheditor in build

### DIFF
--- a/scripts/copyfiles.js
+++ b/scripts/copyfiles.js
@@ -1,4 +1,5 @@
 var fs = require('fs-extra');
+fs.copySync('src/mxgraph/javascript/src/', 'lib/mxgraph/javascript/src/');
 fs.copySync('src/mxgraph/javascript/examples/grapheditor/www/', 'lib/mxgraph/javascript/examples/grapheditor/www/');
 // fs.copySync('src/mxgraph/javascript/examples/grapheditor/www/resources/grapheditor.txt',
 // 			'lib/mxgraph/javascript/examples/grapheditor/www/resources/grapheditor.md');

--- a/scripts/copyfiles.js
+++ b/scripts/copyfiles.js
@@ -1,5 +1,5 @@
 var fs = require('fs-extra');
-fs.copySync('src/mxgraph/', 'lib/mxgraph/');
+fs.copySync('src/mxgraph/javascript/examples/grapheditor/www/', 'lib/mxgraph/javascript/examples/grapheditor/www/');
 // fs.copySync('src/mxgraph/javascript/examples/grapheditor/www/resources/grapheditor.txt',
 // 			'lib/mxgraph/javascript/examples/grapheditor/www/resources/grapheditor.md');
 // fs.copySync('src/mxgraph/javascript/examples/grapheditor/www/resources/grapheditor.txt',


### PR DESCRIPTION
Really only a very small number of files are needed to get the editor working. This change probably still leaves too many (122 files), but at least it's not bringing in all of the other language backends, examples, etc. (2002 files). It drives the result of `npm pack` down from 8.5mb to 3mb, which is a great start.

Also I noticed that mxgraph 3.9.6 dropped, which does contain updates to grapheditor. What's the intended plan for upgrading the vendored stuff, currently at 3.9.0? Is there a compelling reason to not be submoduling to reduce repo churn/size?