### PR TITLE
Update Binder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # jupyterlab-drawio
-[![Binder with JupyterLab](https://img.shields.io/badge/launch-jupyterlab_on_binder-red.svg)](http://mybinder.org/v2/gh/kmader/jupyterlab-drawio/master?urlpath=lab)
+
+[![Binder with JupyterLab](https://mybinder.org/badge_logo.svg)](http://mybinder.org/v2/gh/QuantStack/jupyterlab-drawio/master?urlpath=lab)
 
 
 A JupyterLab extension for standalone integration of drawio / mxgraph into jupyterlab.

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,5 @@
+name: jupyterlab-drawio
+channels:
+- conda-forge
+dependencies:
+- jupyterlab=1.0


### PR DESCRIPTION
- Update the badge
- Explicitly require JupyterLab 1.0 since it's not the default in `repo2docker` (yet)

It would be great to also use a `stable` branch for this repo to have a stable image for Binder.