### PR TITLE
Support JupyterLab 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,731 +49,474 @@
         "tslib": "~1.10.0"
       }
     },
+    "@fortawesome/fontawesome-free": {
+      "version": "5.12.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-5.12.1.tgz",
+      "integrity": "sha512-ZtjIIFplxncqxvogq148C3hBLQE+W3iJ8E4UvJ09zIJUgzwLcROsWwFDErVSXY2Plzao5J9KUYNHKHMEUYDMKw=="
+    },
     "@jupyterlab/application": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-1.2.1.tgz",
-      "integrity": "sha512-CYA0/s/jPNV4x6TtRn4XTVLYOlJIUS7jz2SzxLoSn1sVEg5783y7z6SQPALyYFJINd3XOMgmax3tVVYtQAM2KA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/application/-/application-2.0.2.tgz",
+      "integrity": "sha512-/4KG2jBaUx5s+uuEKpTjJC3kOEQWKmpDNorOLP8PPsdWMl1VlrYJJmnpvIUOLLnJZAycnK7O4z7jBDp6wv4S2Q==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/docregistry": "^1.2.1",
-        "@jupyterlab/rendermime": "^1.2.1",
-        "@jupyterlab/rendermime-interfaces": "^1.5.0",
-        "@jupyterlab/services": "^4.2.0",
-        "@jupyterlab/ui-components": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/application": "^1.7.0",
-        "@phosphor/commands": "^1.7.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
-        "font-awesome": "~4.7.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@fortawesome/fontawesome-free": "^5.12.0",
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/docregistry": "^2.0.2",
+        "@jupyterlab/rendermime": "^2.0.2",
+        "@jupyterlab/rendermime-interfaces": "^2.0.1",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/statedb": "^2.0.1",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/application": "^1.8.4",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/apputils": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-1.2.1.tgz",
-      "integrity": "sha512-xp4GBpMJrK8DTLQmZr0cXwUJElbAbRRtNTxHempigmCEQhzaC1OUN+0M+xOc4Z45Ir0XgcefdCzdwyEUFx1UyQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/apputils/-/apputils-2.0.2.tgz",
+      "integrity": "sha512-mJO/h3x+jtKXPJegdOB5LkvOWLjACKElWCWZXGtizHASYXKrCCAYQ3VDkmrdx2zibu+gDqlMFtbPJxMvYt65Vw==",
       "requires": {
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/services": "^4.2.0",
-        "@jupyterlab/ui-components": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/commands": "^1.7.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/domutils": "^1.1.3",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/virtualdom": "^1.2.0",
-        "@phosphor/widgets": "^1.9.0",
-        "@types/react": "~16.8.18",
-        "react": "~16.8.4",
-        "react-dom": "~16.8.4",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/settingregistry": "^2.0.1",
+        "@jupyterlab/statedb": "^2.0.1",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1",
+        "@lumino/widgets": "^1.11.1",
+        "@types/react": "~16.9.16",
+        "react": "~16.9.0",
+        "react-dom": "~16.9.0",
         "sanitize-html": "~1.20.1"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
       }
     },
     "@jupyterlab/codeeditor": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-1.2.0.tgz",
-      "integrity": "sha512-toejhF/a80X10SZyvEnsnnlS9SxR5W4cz67ju7e/2lsZ8RMwZEDDJAJXyW3mw/EEjt8oVRNP2QpM8L5clE9XyQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codeeditor/-/codeeditor-2.0.2.tgz",
+      "integrity": "sha512-l1SrLJN3QNXQB1WH0YrMjKsM3ZOPAYI05r7hBS0U1Kq5vpb73LQ+8w08s15y/yPcuCgibVhonIEQCyiu1wUA3w==",
       "requires": {
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/dragdrop": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/nbformat": "^2.0.1",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/codemirror": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-1.2.1.tgz",
-      "integrity": "sha512-OtDe4BP9cn9OwY9xsk6foqf+qhnYBtuLIzjoUVbqS4IaHck7gTOA2T2AYBcAFQe9Aj0e/Bb5fo9jBhkVtiFHcA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/codemirror/-/codemirror-2.0.2.tgz",
+      "integrity": "sha512-IQm/yiPHJtQgJlQt/qqX0/pChGsQn/2JIe38q6R2Hi6V4DbI8WpyVOBhhKIoUqWwGNLsZgoCna2dnB+R7j0Emw==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/codeeditor": "^1.2.0",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/statusbar": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/commands": "^1.7.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
-        "codemirror": "~5.47.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        }
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/codeeditor": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/nbformat": "^2.0.1",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/statusbar": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "codemirror": "~5.49.2",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/coreutils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-3.2.0.tgz",
-      "integrity": "sha512-LATiUsHuwze/h3JC2EZOBV+kGBoUKO3npqw/Pcgge4bz09xF/oTDrx4G8jl5eew3w1dCUNp9eLduNh8Orrw7xQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/coreutils/-/coreutils-4.0.2.tgz",
+      "integrity": "sha512-v4RXIAeykoPjIymdCxUxPLl8lkn18jroGnDflZjvdMk21TZQQJSIrJ5bjrGByh9scco8yNg46z8m1LPguF3z8A==",
       "requires": {
-        "@phosphor/commands": "^1.7.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.3.0",
-        "ajv": "^6.5.5",
-        "json5": "^2.1.0",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5",
         "minimist": "~1.2.0",
         "moment": "^2.24.0",
         "path-posix": "~1.0.0",
-        "url-parse": "~1.4.3"
+        "url-parse": "~1.4.7"
       }
     },
     "@jupyterlab/docmanager": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docmanager/-/docmanager-1.2.1.tgz",
-      "integrity": "sha512-4XyXMqx6oxxXW28p/dWX0S5BYwY3RiSKCzN8XuSTfre85jsNQz2712ZyJ51WeevIJ7U+6T/CRRILEv8Jo5SNbg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docmanager/-/docmanager-2.0.2.tgz",
+      "integrity": "sha512-59/Oa/akU2pzKF96OFOV+vz8s9xpEVowe6NIhJooOxU6AZdDsN3o2sMCVkoCsnlnwPQ8N6siGKbBP9QlPk0taQ==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/docregistry": "^1.2.1",
-        "@jupyterlab/services": "^4.2.0",
-        "@jupyterlab/statusbar": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/docregistry": "^2.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/statusbar": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/docregistry": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-1.2.1.tgz",
-      "integrity": "sha512-EUj0c6VKB5YD7RrH/b4xyJLExNsgKNjysegLLN9dFGamz4azfylOJlbxqyN1n1GeLIG4rGsGT1pD7qzDlTQGEA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/docregistry/-/docregistry-2.0.2.tgz",
+      "integrity": "sha512-kGk1AIzcXkpaNI1pwFbyLYiQuSdJUQ/j2A+G8WYhcY64Zwp1tayr0VvaRuEzwcDHueiBYesaarCxY7VNP+Cf3g==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/codeeditor": "^1.2.0",
-        "@jupyterlab/codemirror": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/rendermime": "^1.2.1",
-        "@jupyterlab/rendermime-interfaces": "^1.5.0",
-        "@jupyterlab/services": "^4.2.0",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/codeeditor": "^2.0.2",
+        "@jupyterlab/codemirror": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/rendermime": "^2.0.2",
+        "@jupyterlab/rendermime-interfaces": "^2.0.1",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/filebrowser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/filebrowser/-/filebrowser-1.2.1.tgz",
-      "integrity": "sha512-OQS72Pf41npmpt+t5RRRPqhCqO+J1vzTQtFLOq6MvLMTY+xF/sNR8AUSFWr6J05czPYMfnRhhpkHORqYmYwtGQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/filebrowser/-/filebrowser-2.0.2.tgz",
+      "integrity": "sha512-jztQ3NVfkjd4LqtQYxsfVmGf5D5pCk4F9/ktH2PESA3V02uQMkuRZ24u0cikdzz05cEp05Oe94/9gba9SPCE0A==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/docmanager": "^1.2.1",
-        "@jupyterlab/docregistry": "^1.2.1",
-        "@jupyterlab/services": "^4.2.0",
-        "@jupyterlab/statusbar": "^1.2.1",
-        "@jupyterlab/ui-components": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/domutils": "^1.1.3",
-        "@phosphor/dragdrop": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/docmanager": "^2.0.2",
+        "@jupyterlab/docregistry": "^2.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/statedb": "^2.0.1",
+        "@jupyterlab/statusbar": "^2.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/launcher": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/launcher/-/launcher-1.2.1.tgz",
-      "integrity": "sha512-me1tmAeohLI2ofRg0i0kWUVZRj/RdgPJV5FAT7+oMF/dX1tj5HdcoOW/l8gRCdjflniO/IHD3Ei5UZoAo9EN7A==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/launcher/-/launcher-2.0.2.tgz",
+      "integrity": "sha512-3vFRUCvHJkpBSp3/6e2sDwAdOLW8h957wnw6pAvysiwvgBNB66QZ4P72/HhN5QuhDDz6VQn//M5HztKz0NRF4A==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/ui-components": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/commands": "^1.7.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/widgets": "^1.9.0",
-        "react": "~16.8.4"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        }
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0"
       }
     },
     "@jupyterlab/mainmenu": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/mainmenu/-/mainmenu-1.2.1.tgz",
-      "integrity": "sha512-T1WfTOkzMtbE1zXVeMM2oCTz/wvAPoeQiKTlsSLOLOP5rDl3fbDx7EWHAHRqDyGPbakTbqiQPHrbqRRiGhayDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/mainmenu/-/mainmenu-2.0.2.tgz",
+      "integrity": "sha512-jeDx1uYE4QpAVWy3XdJIQ73+J1Mb5YXRrQkTG4S0SsT248Kkl7uz0i2j+EE7RNJlGvJlD1t+SjSuOtegZvRpnA==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/services": "^4.2.0",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/commands": "^1.7.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        }
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/widgets": "^1.11.1"
+      }
+    },
+    "@jupyterlab/nbformat": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/nbformat/-/nbformat-2.0.1.tgz",
+      "integrity": "sha512-rlf4A3PKxqDV98IeXf/VtdhqcbnKvBRGL+VNxhMOZe3e+DmjIBilRE+VpHmXovwEanOAkNl0fD5Xk3HAkqxxGQ==",
+      "requires": {
+        "@lumino/coreutils": "^1.4.2"
       }
     },
     "@jupyterlab/observables": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-2.4.0.tgz",
-      "integrity": "sha512-M/fhAnPqd6F4Zwt4IIsvHCkJmwbSw1Tko/hUXgdUQG86lPsJiTOh98sB3qwV1gtzb9oFF+kH21XsHnQZ6Yl6Pw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/observables/-/observables-3.0.1.tgz",
+      "integrity": "sha512-iD7w8JYBRT9UXVS3IvljvoDf0ZiHQEu1Pm+784UTa27Az0i6idyV1iWZ+xIHtV+s7ampVjMGiBbqXD6m4HRNpg==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5"
       }
     },
     "@jupyterlab/rendermime": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-1.2.1.tgz",
-      "integrity": "sha512-S57dOCQRXoGpUl9bGryAgAcLlDbXBk+Y8HPR2oO95slgk45vVktWl+6f/euNQcjOCX+RkuQuLLsBYeWzCZKCRw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime/-/rendermime-2.0.2.tgz",
+      "integrity": "sha512-JUGUteRLrwEHX5kPU1rLAIzChEwEQyxDbSCes63fgO5Hn+JXNKKQexWXeHZOm5l1JBGNiokQCz8Jy6fQHmEMYQ==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/codemirror": "^1.2.1",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@jupyterlab/rendermime-interfaces": "^1.5.0",
-        "@jupyterlab/services": "^4.2.0",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/codemirror": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/nbformat": "^2.0.1",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/rendermime-interfaces": "^2.0.1",
+        "@jupyterlab/services": "^5.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
         "lodash.escape": "^4.0.1",
-        "marked": "^0.7.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "marked": "^0.8.0"
       }
     },
     "@jupyterlab/rendermime-interfaces": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-1.5.0.tgz",
-      "integrity": "sha512-k6DjX/srKl1FA1CZyrAzz1qA2v1arXUIAmbEddZ5L3O+dnvDlOKjkI/NexaRQvmQ62aziSln+wKrr2P1JPNmGg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/rendermime-interfaces/-/rendermime-interfaces-2.0.1.tgz",
+      "integrity": "sha512-QYJcQNKNmrBXHXC31AvBRYk+QqKB0rZrvVXbhggFXBQiYQX1K/lnFvKjphmhhnpUhLKtgUrex+04cJ9Kek00HA==",
       "requires": {
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/widgets": "^1.9.0"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/widgets": "^1.11.1"
       }
     },
     "@jupyterlab/services": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-4.2.0.tgz",
-      "integrity": "sha512-diqiWCYLROwZoeZ46hO4oCINQKr3S789GOA3drw5gDie18/u1nJcvegnY9Oo58xHINnKTs0rKZmFgTe2DvYgQg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/services/-/services-5.0.2.tgz",
+      "integrity": "sha512-gBwXikSRWIrj0XiuYMSXd0TXLZJrE18rTtRwrvne0T/gJPg0+4JbORPkaKfFdbX84oQv8XLOT74xUHSPDhst0A==",
       "requires": {
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/observables": "^2.4.0",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/nbformat": "^2.0.1",
+        "@jupyterlab/observables": "^3.0.1",
+        "@jupyterlab/settingregistry": "^2.0.1",
+        "@jupyterlab/statedb": "^2.0.1",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
         "node-fetch": "^2.6.0",
-        "ws": "^7.0.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        }
+        "ws": "^7.2.0"
+      }
+    },
+    "@jupyterlab/settingregistry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/settingregistry/-/settingregistry-2.0.1.tgz",
+      "integrity": "sha512-38c5CFXLLNT1zKk0vS/UoD7TA90YpOrs/I5Zc8wY8GIl31IzTmTgre5H5cFSgvgg/imEbsYVWiUXtvTuQHGDWw==",
+      "requires": {
+        "@jupyterlab/statedb": "^2.0.1",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5",
+        "ajv": "^6.10.2",
+        "json5": "^2.1.1"
+      }
+    },
+    "@jupyterlab/statedb": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statedb/-/statedb-2.0.1.tgz",
+      "integrity": "sha512-M8Z9yc5grOa0dspEFBkB3qetAozPKbXYryOCaB2/MYBalTaZfNivJyVVnxf3xQRKolYavOn9ohONmuQq0OMFWQ==",
+      "requires": {
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5"
       }
     },
     "@jupyterlab/statusbar": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-1.2.1.tgz",
-      "integrity": "sha512-T+wmFQwW4tRHDDlY8A6i46G4HE7MP4EXMxcaNnYmPb+HElTgSx9KSrJ4cGRhFNdh5y0PcWwCD4wFUH5qAkEFYg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/statusbar/-/statusbar-2.0.2.tgz",
+      "integrity": "sha512-CGSaIm62ABWrQzAt6Jr79Px1iJMZw+LqlSVGMUDK7uPpeQ0w2Sk0V2B9bydSqJyDyzb/Ja495CYRqLu6rJn94A==",
       "requires": {
-        "@jupyterlab/apputils": "^1.2.1",
-        "@jupyterlab/codeeditor": "^1.2.0",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@jupyterlab/services": "^4.2.0",
-        "@jupyterlab/ui-components": "^1.2.1",
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.0",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/signaling": "^1.3.0",
-        "@phosphor/widgets": "^1.9.0",
-        "react": "~16.8.4",
-        "typestyle": "^2.0.1"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@jupyterlab/apputils": "^2.0.2",
+        "@jupyterlab/codeeditor": "^2.0.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@jupyterlab/services": "^5.0.2",
+        "@jupyterlab/ui-components": "^2.0.2",
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/polling": "^1.0.4",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/widgets": "^1.11.1",
+        "csstype": "~2.6.9",
+        "react": "~16.9.0",
+        "typestyle": "^2.0.4"
       }
     },
     "@jupyterlab/ui-components": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-1.2.1.tgz",
-      "integrity": "sha512-GUtIRwTmFnlJaPUM8SiFw1STmsyMVGjchLKqIoQnn0qYAJvaSUGyRqqoSD5iIpwov6OHCOOyxH6fQ5OAtH1kwA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@jupyterlab/ui-components/-/ui-components-2.0.2.tgz",
+      "integrity": "sha512-yQ/M3ZtA/Zo8qsvvcwe17qdeTE7xZ6U5l5M/6OVvxIMKR0qXnqSpv8w7jJAgbRusr29Dj8tHbdrEMFethlfwUg==",
       "requires": {
-        "@blueprintjs/core": "^3.9.0",
-        "@blueprintjs/select": "^3.3.0",
-        "@jupyterlab/coreutils": "^3.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/virtualdom": "^1.2.0",
-        "@phosphor/widgets": "^1.9.0",
-        "react": "~16.8.4",
-        "typestyle": "^2.0.1"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@blueprintjs/core": "^3.22.2",
+        "@blueprintjs/select": "^3.11.2",
+        "@jupyterlab/coreutils": "^4.0.2",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1",
+        "@lumino/widgets": "^1.11.1",
+        "react": "~16.9.0",
+        "react-dom": "~16.9.0",
+        "typestyle": "^2.0.4"
       }
     },
-    "@phosphor/algorithm": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.1.2.tgz",
-      "integrity": "sha1-/R3pEEyafzTpKGRYbd8ufy53eeg=",
-      "dev": true
+    "@lumino/algorithm": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/algorithm/-/algorithm-1.2.3.tgz",
+      "integrity": "sha512-XBJ/homcm7o8Y9G6MzYvf0FF7SVqUCzvkIO01G2mZhCOnkZZhZ9c4uNOcE2VjSHNxHv2WU0l7d8rdhyKhmet+A=="
     },
-    "@phosphor/application": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/application/-/application-1.7.3.tgz",
-      "integrity": "sha512-ohxrW7rv5Tms4PSyPRZT6YArZQQGQNG4MgTeFzkoLJ+7mp/BcbFuvEoaV1/CUKQArofl0DCkKDOTOIkXP+/32A==",
+    "@lumino/application": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/@lumino/application/-/application-1.8.4.tgz",
+      "integrity": "sha512-f+CgggJ/9jopHT6db76+BjsiPBHjv6fgReU/vKtRGg8rsDjNRDefoWd9bWGWRuPiGymBY8c/+9Kyq5v0UDs5vg==",
       "requires": {
-        "@phosphor/commands": "^1.7.2",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/widgets": "^1.9.3"
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/widgets": "^1.11.1"
       }
     },
-    "@phosphor/collections": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.1.2.tgz",
-      "integrity": "sha1-xMC4uREpkF+zap8kPy273kYtq40=",
-      "dev": true,
+    "@lumino/collections": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lumino/collections/-/collections-1.2.3.tgz",
+      "integrity": "sha512-lrSTb7kru/w8xww8qWqHHhHO3GkoQeXST2oNkOEbWNEO4wuBIHoKPSOmXpUwu58UykBUfd5hL5wbkeTzyNMONg==",
       "requires": {
-        "@phosphor/algorithm": "1.1.2"
+        "@lumino/algorithm": "^1.2.3"
       }
     },
-    "@phosphor/commands": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/commands/-/commands-1.7.2.tgz",
-      "integrity": "sha512-iSyBIWMHsus323BVEARBhuVZNnVel8USo+FIPaAxGcq+icTSSe6+NtSxVQSmZblGN6Qm4iw6I6VtiSx0e6YDgQ==",
+    "@lumino/commands": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@lumino/commands/-/commands-1.10.1.tgz",
+      "integrity": "sha512-HGtXtqKD1WZJszJ42u2DyM3sgxrLal66IoHSJjbn2ygcEVCKDK73NSzoaQtXFtiissMedzKl8aIRXB3uyeEOlw==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.1",
-        "@phosphor/domutils": "^1.1.4",
-        "@phosphor/keyboard": "^1.1.3",
-        "@phosphor/signaling": "^1.3.1"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        }
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/keyboard": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1"
       }
     },
-    "@phosphor/coreutils": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/coreutils/-/coreutils-1.3.1.tgz",
-      "integrity": "sha512-9OHCn8LYRcPU/sbHm5v7viCA16Uev3gbdkwqoQqlV+EiauDHl70jmeL7XVDXdigl66Dz0LI11C99XOxp+s3zOA=="
+    "@lumino/coreutils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@lumino/coreutils/-/coreutils-1.4.2.tgz",
+      "integrity": "sha512-SmQ4YDANe25rZd0bLoW7LVAHmgySjkrJmyNPnPW0GrpBt2u4/6D+EQJ8PCCMNWuJvrljBCdlmgOFsT38qYhfcw=="
     },
-    "@phosphor/disposable": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/disposable/-/disposable-1.3.1.tgz",
-      "integrity": "sha512-0NGzoTXTOizWizK/brKKd5EjJhuuEH4903tLika7q6wl/u0tgneJlTh7R+MBVeih0iNxtuJAfBa3IEY6Qmj+Sw==",
+    "@lumino/disposable": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/disposable/-/disposable-1.3.5.tgz",
+      "integrity": "sha512-IWDAd+nysBnwLhEtW7M62PVk84OEex9OEktZsS6V+19n/o8/Rw4ccL0pt0GFby01CsVK0YcELDoDaMUZsMiAmA==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/signaling": "^1.3.1"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        }
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/signaling": "^1.3.5"
       }
     },
-    "@phosphor/domutils": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@phosphor/domutils/-/domutils-1.1.4.tgz",
-      "integrity": "sha512-ivwq5TWjQpKcHKXO8PrMl+/cKqbgxPClPiCKc1gwbMd+6hnW5VLwNG0WBzJTxCzXK43HxX18oH+tOZ3E04wc3w=="
+    "@lumino/domutils": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@lumino/domutils/-/domutils-1.1.7.tgz",
+      "integrity": "sha512-NPysY8XfpCvLNvDe+z1caIUPxOLXWRPQMUAjOj/EhggRyXadan6Lm/5uO6M9S5gW/v9QUXT4+1Sxe3WXz0nRCA=="
     },
-    "@phosphor/dragdrop": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/dragdrop/-/dragdrop-1.4.1.tgz",
-      "integrity": "sha512-77paMoubIWk7pdwA2GVFkqba1WP48hTZZvS17N30+KVOeWfSqBL3flPSnW2yC4y6FnOP2PFOCtuPIbQv+pYhCA==",
+    "@lumino/dragdrop": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-1.5.1.tgz",
+      "integrity": "sha512-MFg/hy6hHdPwBZypBue5mlrBzjoNrtBQzzJW+kbM5ftAOvS99ZRgyMMlMQcbsHd+6yib9NOQ64Hd8P8uZEWTdw==",
       "requires": {
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.1"
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5"
       }
     },
-    "@phosphor/keyboard": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/keyboard/-/keyboard-1.1.3.tgz",
-      "integrity": "sha512-dzxC/PyHiD6mXaESRy6PZTd9JeK+diwG1pyngkyUf127IXOEzubTIbu52VSdpGBklszu33ws05BAGDa4oBE4mQ=="
+    "@lumino/keyboard": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-1.1.6.tgz",
+      "integrity": "sha512-W6pqe0TXRfGOoz1ZK1PRmuGZUWpmdoJArrzwmduUf0t2r06yl56S7w76gxrB7ExTidNPPaOWydGIosPgdgZf5A=="
     },
-    "@phosphor/messaging": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.2.2.tgz",
-      "integrity": "sha1-fYlt3TeXuUo0dwje0T2leD23XBQ=",
-      "dev": true,
+    "@lumino/messaging": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@lumino/messaging/-/messaging-1.3.3.tgz",
+      "integrity": "sha512-J+0m1aywl64I9/dr9fzE9IwC+eq90T5gUi1hCXP1MFnZh4aLUymmRV5zFw1CNh/vYlNnEu72xxEuhfCfuhiy8g==",
       "requires": {
-        "@phosphor/algorithm": "1.1.2",
-        "@phosphor/collections": "1.1.2"
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/collections": "^1.2.3"
       }
     },
-    "@phosphor/properties": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/properties/-/properties-1.1.3.tgz",
-      "integrity": "sha512-GiglqzU77s6+tFVt6zPq9uuyu/PLQPFcqZt914ZhJ4cN/7yNI/SLyMzpYZ56IRMXvzK9TUgbRna6URE3XAwFUg=="
-    },
-    "@phosphor/signaling": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@phosphor/signaling/-/signaling-1.3.1.tgz",
-      "integrity": "sha512-Eq3wVCPQAhUd9+gUGaYygMr+ov7dhSGblSBXiDzpZlSIfa8OVD4P3cCvYXr/acDTNmZ/gHTcSFO8/n3rDkeXzg==",
+    "@lumino/polling": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@lumino/polling/-/polling-1.0.4.tgz",
+      "integrity": "sha512-9OYIDTohToj6SLrxOr+FbeyPvirBU/r53FgmPxulcDgUVnVk4tqTSLIJAUu3mjJd9hnmZZqpSn9ppyjQAo3qSg==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        }
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/signaling": "^1.3.5"
       }
     },
-    "@phosphor/virtualdom": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@phosphor/virtualdom/-/virtualdom-1.2.0.tgz",
-      "integrity": "sha512-L9mKNhK2XtVjzjuHLG2uYuepSz8uPyu6vhF4EgCP0rt0TiLYaZeHwuNu3XeFbul9DMOn49eBpye/tfQVd4Ks+w==",
+    "@lumino/properties": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@lumino/properties/-/properties-1.1.6.tgz",
+      "integrity": "sha512-QnZa1IB7sr4Tawf0OKvwgZAptxDRK7DUAMJ71zijXNXH4FlxyThzOWXef51HHFsISKYa8Rn3rysOwtc62XkmXw=="
+    },
+    "@lumino/signaling": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@lumino/signaling/-/signaling-1.3.5.tgz",
+      "integrity": "sha512-6jniKrLrJOXKJmaJyU7hr6PBzE4GJ5Wms5hc/yzNKKDBxGSEPdtNJlW3wTNUuSTTtF/9ItN8A8ZC/G0yIu53Tw==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        }
+        "@lumino/algorithm": "^1.2.3"
       }
     },
-    "@phosphor/widgets": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/@phosphor/widgets/-/widgets-1.9.3.tgz",
-      "integrity": "sha512-61jsxloDrW/+WWQs8wOgsS5waQ/MSsXBuhONt0o6mtdeL93HVz7CYO5krOoot5owammfF6oX1z0sDaUYIYgcPA==",
+    "@lumino/virtualdom": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@lumino/virtualdom/-/virtualdom-1.6.1.tgz",
+      "integrity": "sha512-+KdzSw8TCPwvK6qhZr4xTyp6HymvEb2Da0xPdi4RsVUNhYf2gBI03uidXHx76Vx5OIbEgCn1B+0srxvm2ZbWsQ==",
       "requires": {
-        "@phosphor/algorithm": "^1.2.0",
-        "@phosphor/commands": "^1.7.2",
-        "@phosphor/coreutils": "^1.3.1",
-        "@phosphor/disposable": "^1.3.1",
-        "@phosphor/domutils": "^1.1.4",
-        "@phosphor/dragdrop": "^1.4.1",
-        "@phosphor/keyboard": "^1.1.3",
-        "@phosphor/messaging": "^1.3.0",
-        "@phosphor/properties": "^1.1.3",
-        "@phosphor/signaling": "^1.3.1",
-        "@phosphor/virtualdom": "^1.2.0"
-      },
-      "dependencies": {
-        "@phosphor/algorithm": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/algorithm/-/algorithm-1.2.0.tgz",
-          "integrity": "sha512-C9+dnjXyU2QAkWCW6QVDGExk4hhwxzAKf5/FIuYlHAI9X5vFv99PYm0EREDxX1PbMuvfFBZhPNu0PvuSDQ7sFA=="
-        },
-        "@phosphor/collections": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/collections/-/collections-1.2.0.tgz",
-          "integrity": "sha512-T9/0EjSuY6+ga2LIFRZ0xupciOR3Qnyy8Q95lhGTC0FXZUFwC8fl9e8On6IcwasCszS+1n8dtZUWSIynfgdpzw==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0"
-          }
-        },
-        "@phosphor/messaging": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/@phosphor/messaging/-/messaging-1.3.0.tgz",
-          "integrity": "sha512-k0JE+BTMKlkM335S2AmmJxoYYNRwOdW5jKBqLgjJdGRvUQkM0+2i60ahM45+J23atGJDv9esKUUBINiKHFhLew==",
-          "requires": {
-            "@phosphor/algorithm": "^1.2.0",
-            "@phosphor/collections": "^1.2.0"
-          }
-        }
+        "@lumino/algorithm": "^1.2.3"
+      }
+    },
+    "@lumino/widgets": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-1.11.1.tgz",
+      "integrity": "sha512-f4QDe6lVNPcjL8Vb20BiP0gzbT1rx0/1Hc719u5oW9c0Z/xrXMWwNhnb/zYM/kBBVBe3omLmCfJOiNuE0oZl0A==",
+      "requires": {
+        "@lumino/algorithm": "^1.2.3",
+        "@lumino/commands": "^1.10.1",
+        "@lumino/coreutils": "^1.4.2",
+        "@lumino/disposable": "^1.3.5",
+        "@lumino/domutils": "^1.1.7",
+        "@lumino/dragdrop": "^1.5.1",
+        "@lumino/keyboard": "^1.1.6",
+        "@lumino/messaging": "^1.3.3",
+        "@lumino/properties": "^1.1.6",
+        "@lumino/signaling": "^1.3.5",
+        "@lumino/virtualdom": "^1.6.1"
       }
     },
     "@types/dom4": {
@@ -787,9 +530,9 @@
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
     "@types/react": {
-      "version": "16.8.25",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.8.25.tgz",
-      "integrity": "sha512-ydAAkLnNTC4oYSxJ3zwK/4QcVmEecACJ4ZdxXITbxz/dhahBSDKY6OQ1uawAW6rE/7kfHccxulYLSAIZVrSq0A==",
+      "version": "16.9.23",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.23.tgz",
+      "integrity": "sha512-SsGVT4E7L2wLN3tPYLiF20hmZTPGuzaayVunfgXzUn1x4uHVsKH6QDJQ/TdpHqwsTLd4CwrmQ2vOgxN7gE24gw==",
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
@@ -831,7 +574,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -851,9 +594,9 @@
       "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "codemirror": {
-      "version": "5.47.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.47.0.tgz",
-      "integrity": "sha512-kV49Fr+NGFHFc/Imsx6g180hSlkGhuHxTSDDmDHOuyln0MQYFLixDY4+bFkBVeCEiepYfDimAF/e++9jPJk4QA=="
+      "version": "5.49.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.49.2.tgz",
+      "integrity": "sha512-dwJ2HRPHm8w51WB5YTF9J7m6Z5dtkqbU9ntMZ1dqXyFB9IpjoUFDj80ahRVEoVanfIp6pfASJbOlbWdEf8FOzQ=="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -1013,11 +756,6 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
     },
-    "font-awesome": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
-      "integrity": "sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM="
-    },
     "free-style": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/free-style/-/free-style-2.6.1.tgz",
@@ -1051,12 +789,12 @@
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-fs": {
@@ -1107,8 +845,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -1158,16 +896,16 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json5": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-      "integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+      "integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
       "requires": {
-        "minimist": "^1.2.0"
+        "minimist": "^1.2.5"
       }
     },
     "jsonfile": {
       "version": "4.0.0",
-      "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
       "dev": true,
       "requires": {
@@ -1213,9 +951,9 @@
       }
     },
     "marked": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.7.0.tgz",
-      "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.0.tgz",
+      "integrity": "sha512-MyUe+T/Pw4TZufHkzAfDj6HarCBWia2y27/bhuYkTaiUnfDYFnCP3KUN+9oM7Wi6JA2rymtVYbQu3spE0GCmxQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -1223,17 +961,17 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
       "version": "1.2.5",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
     },
     "moment": {
       "version": "2.24.0",
-      "resolved": "http://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "node-fetch": {
@@ -1288,7 +1026,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -1348,25 +1086,24 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "react": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
-      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.9.0.tgz",
+      "integrity": "sha512-+7LQnFBwkiw+BobzOF6N//BdoNw0ouwmSJTEm9cglOOmsg/TMiFHZLe2sEoN5M7LgJTj9oHH0gxklfnQe66S1w==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "prop-types": "^15.6.2"
       }
     },
     "react-dom": {
-      "version": "16.8.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
-      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
+      "version": "16.9.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.9.0.tgz",
+      "integrity": "sha512-YFT2rxO9hM70ewk9jq0y6sQk8cL02xm4+IzYBz75CQGlClQQ1Bxq0nhHF6OtSbit+AIahujJgb/CPRibFkMNJQ==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.13.6"
+        "scheduler": "^0.15.0"
       }
     },
     "react-is": {
@@ -1406,7 +1143,7 @@
     },
     "readable-stream": {
       "version": "3.6.0",
-      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
       "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
       "requires": {
         "inherits": "^2.0.3",
@@ -1444,7 +1181,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.3"
+        "glob": "^7.0.5"
       }
     },
     "safe-buffer": {
@@ -1470,9 +1207,9 @@
       }
     },
     "scheduler": {
-      "version": "0.13.6",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
-      "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.15.0.tgz",
+      "integrity": "sha512-xAefmSfN6jqAa7Kuq7LIJY0bwAPG3xlCj0HMEBQk1lxYiDKZscY2xJ5U/61ZTrYbmNQbXa+gc7czPkVo11tnCg==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -1537,9 +1274,9 @@
       "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.7.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
+      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
       "dev": true
     },
     "typestyle": {

--- a/package.json
+++ b/package.json
@@ -31,19 +31,19 @@
     "prepublish": "npm run clean && npm run build"
   },
   "dependencies": {
-    "@jupyterlab/application": "^1.0.0",
-    "@jupyterlab/apputils": "^1.0.0",
-    "@jupyterlab/coreutils": "^3.0.0",
-    "@jupyterlab/docregistry": "^1.0.0",
-    "@jupyterlab/filebrowser": "^1.0.0",
-    "@jupyterlab/launcher": "^1.0.0",
-    "@jupyterlab/mainmenu": "^1.0.0"
+    "@jupyterlab/application": "^2.0.0",
+    "@jupyterlab/apputils": "^2.0.0",
+    "@jupyterlab/coreutils": "^4.0.0",
+    "@jupyterlab/docregistry": "^2.0.0",
+    "@jupyterlab/filebrowser": "^2.0.0",
+    "@jupyterlab/launcher": "^2.0.0",
+    "@jupyterlab/mainmenu": "^2.0.0"
   },
   "devDependencies": {
     "rimraf": "^2.6.1",
-    "typescript": "~3.5.2",
+    "typescript": "~3.7.0",
     "fs-extra": "^8.1.0",
-    "@phosphor/messaging": "^1.1.0"
+    "@lumino/messaging": "^1.1.0"
   },
   "jupyterlab": {
     "extension": true

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -44,15 +44,15 @@ import {
 
 import {
   Widget
-} from '@phosphor/widgets';
+} from '@lumino/widgets';
 
 import {
   Message
-} from '@phosphor/messaging';
+} from '@lumino/messaging';
 
 import {
   PromiseDelegate
-} from '@phosphor/coreutils';
+} from '@lumino/coreutils';
 
 import './mxgraph/javascript/src/css/common.css';
 import './mxgraph/javascript/examples/grapheditor/www/styles/grapheditor.css';

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import {
 
 import {
   Token
-} from '@phosphor/coreutils';
+} from '@lumino/coreutils';
 
 import {
   DrawioWidget, DrawioFactory


### PR DESCRIPTION
Fixes #51.

After this PR is merged, future releases of this extension will now require JupyterLab 2, but if JupyterLab 1 is used an old versions of this package can still be used automatically instead.