### PR TITLE
Re-apply load performance and bundle size/content changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules/
 *.egg-info/
 .ipynb_checkpoints
 tsconfig.tsbuildinfo
+*.tgz

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,5 +1,8 @@
 name: jupyterlab-drawio
+
 channels:
-- conda-forge
+  - conda-forge
+
 dependencies:
-- jupyterlab=1.0
+  - jupyterlab >=2,<3.0.0a0
+  - nodejs

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -5,4 +5,4 @@ channels:
 
 dependencies:
   - jupyterlab >=2,<3.0.0a0
-  - nodejs
+  - nodejs >=10

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -eux
 npm install
+npm build
 jupyter labextension install $(npm pack .) --no-build --debug
 jupyter lab build --dev-build=False --minimize=True --debug

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eux
 npm install
-jupyter labextension install . --no-build --debug
+jupyter labextension install $(npm pack) --no-build --debug
 jupyter lab build --dev-build=False --minimize=True --debug

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,5 @@
-jupyter labextension install jupyterlab-drawio
+#!/usr/bin/env bash
+set -eux
+npm install
+jupyter labextension install . --no-build --debug
+jupyter lab build --dev-build=False --minimize=True --debug

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -eux
 npm install
-npm build
+npm run build
 npm pack
 jupyter labextension install ./jupyterlab-drawio-*.tgz --no-build --debug
 jupyter lab build --dev-build=False --minimize=True --debug
+jupyter labextension list

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,5 +2,6 @@
 set -eux
 npm install
 npm build
-jupyter labextension install $(npm pack .) --no-build --debug
+npm pack
+jupyter labextension install ./jupyterlab-drawio-*.tgz --no-build --debug
 jupyter lab build --dev-build=False --minimize=True --debug

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 set -eux
 npm install
-jupyter labextension install $(npm pack) --no-build --debug
+jupyter labextension install $(npm pack .) --no-build --debug
 jupyter lab build --dev-build=False --minimize=True --debug

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "scripts": {
     "build": "node scripts/copyfiles.js && tsc",
     "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "watch": "tsc -w",
-    "prepublish": "npm run clean && npm run build"
+    "watch": "tsc -w"
   },
   "dependencies": {
     "@jupyterlab/application": "^2.0.0",

--- a/scripts/copyfiles.js
+++ b/scripts/copyfiles.js
@@ -1,5 +1,7 @@
 var fs = require('fs-extra');
-fs.copySync('src/mxgraph/', 'lib/mxgraph/');
+
+fs.copySync('src/mxgraph/javascript/src/', 'lib/mxgraph/javascript/src/');
+fs.copySync('src/mxgraph/javascript/examples/grapheditor/www/', 'lib/mxgraph/javascript/examples/grapheditor/www/');
 // fs.copySync('src/mxgraph/javascript/examples/grapheditor/www/resources/grapheditor.txt',
 // 			'lib/mxgraph/javascript/examples/grapheditor/www/resources/grapheditor.md');
 // fs.copySync('src/mxgraph/javascript/examples/grapheditor/www/resources/grapheditor.txt',

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -28,7 +28,7 @@ w.OPEN_FORM = web_path +  'open.html';
 w.mxLoadStylesheets = false;  // disable loading stylesheets
 w.mxLoadResources = false;
 
-/* This is a typing-only commit. If you use it directly, the mxgraph content
+/* This is a typing-only import. If you use it directly, the mxgraph content
    will be included in the main JupyterLab js bundle.
 */
 import * as MXModuleType from './mxgraph/javascript/examples/grapheditor/www/modulated.js';
@@ -242,6 +242,9 @@ namespace Private {
     let _mx: typeof MXModuleType;
     let _mxLoading: PromiseDelegate<MX>;
 
+    /**
+     * Asynchronously load the mx bundle, or return it if already available
+     */
     export async function ensureMx(): Promise<MX> {
         if (_mx)
         {


### PR DESCRIPTION
Hey folks! Thanks for keeping this up and running!

There's so much that could be done with drawio integeration, but just a few 
things are making hard to (re)use effectively.

Anyhow, for the most part, this is a rehash of #20 and #19, updated for JupyterLab 2.
- [x] asynchronously load mx
- [x] substantially reduce the total bundle side, only copying the relevant assets
- [x] make binder install the latest dev version
    - the docs could be expanded to have links to the last stable tag, as well

Here's it up on binder:

[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/bollwyvl/jupyterlab-drawio/perf/async-load-again?urlpath=lab%2Ftree%2Ftestfiles%2FTestFile.dio)

Thanks again!