### PR TITLE
Add mamba and conda instructions to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,29 @@
 
 A JupyterLab extension for embedding drawio / mxgraph.
 
-
-
 ## Requirements
 
 * JupyterLab >= 3.0
 
 ## Install
 
+`jupyterlab-drawio` can be installed with [`mamba`](https://github.com/mamba-org/mamba):
+
+```bash
+mamba install -c conda-forge jupyterlab-drawio
+```
+
+With `conda`:
+
+```bash
+conda install -c conda-forge jupyterlab-drawio
+```
+
+With `pip`:
+
 ```bash
 pip install jupyterlab-drawio
 ```
-
 
 ## Contributing
 


### PR DESCRIPTION
Now that `jupyterlab-drawio` has been added to conda forge:

- https://github.com/conda-forge/jupyterlab-drawio-feedstock
- https://anaconda.org/conda-forge/jupyterlab-drawio